### PR TITLE
Upgrade version of Amazon QLDB driver to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ npm run doc
 ```
 
 ## Release Notes
+### Release 1.0.0
+
+* Modify the sample app to use Qldb Node.js Driver v1.0.0
 
 ### Release 1.0.0-rc.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-qldb-dmv-sample-nodejs",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -135,9 +135,9 @@
       }
     },
     "amazon-qldb-driver-nodejs": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-1.0.0-rc.2.tgz",
-      "integrity": "sha512-vGhtjG/FnHdR6z62OJnKI2yoLkdi+gZPV4Wzbz41KhKUwYMSiOVusSB0KkQVuN2Oo2znbhcuXDc06Zt5vWszbQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-1.0.0.tgz",
+      "integrity": "sha512-z0z/bE141liFc6JTf8qdiU+186+CHYx5wJth4x/Chgw/+EI9zCrHg6Wp2eocdKgkIbe5mLKt3aSEtn1PmFILIg==",
       "requires": {
         "@types/node": "12.0.2",
         "ion-hash-js": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "@types/node": "^12.0.2",
-    "amazon-qldb-driver-nodejs": "^1.0.0-rc.2",
+    "amazon-qldb-driver-nodejs": "^1.0.0",
     "aws-sdk": "^2.564.0",
     "ion-js": "~4.0.0",
     "jsbi": "^3.1.1"
   },
   "name": "amazon-qldb-dmv-sample-nodejs",
   "description": "Amazon Quantum Ledger Database Node.js sample application",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
Upgrade version of Amazon QLDB driver to [v1.0.0](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0) . There are no code changes introduced between [v1.0.0-rc.2](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.2) and [v1.0.0](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0) of the driver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
