### PR TITLE
Update the Sample app to use Amazon QLDB Node.js Driver v2.0.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,9 +135,9 @@
       }
     },
     "amazon-qldb-driver-nodejs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-1.0.0.tgz",
-      "integrity": "sha512-z0z/bE141liFc6JTf8qdiU+186+CHYx5wJth4x/Chgw/+EI9zCrHg6Wp2eocdKgkIbe5mLKt3aSEtn1PmFILIg==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/amazon-qldb-driver-nodejs/-/amazon-qldb-driver-nodejs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-H2UnSvduCbtC0ZFRfNZIUGTfYGV97MnRciwSsR/Ielq71PI2+nU71znmful4JIrNomfoiTS545NGqKR16orpyg==",
       "requires": {
         "@types/node": "12.0.2",
         "ion-hash-js": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@types/node": "^12.0.2",
-    "amazon-qldb-driver-nodejs": "^1.0.0",
+    "amazon-qldb-driver-nodejs": "2.0.0-rc.1",
     "aws-sdk": "^2.564.0",
     "ion-js": "~4.0.0",
     "jsbi": "^3.1.1"

--- a/src/AddSecondaryOwner.ts
+++ b/src/AddSecondaryOwner.ts
@@ -113,7 +113,7 @@ var main = async function(): Promise<void> {
             } else {
                 await addSecondaryOwner(txn, vin, documentId);
             }
-        }, () => log("Retrying due to OCC conflict..."));
+        });
 
         log("Secondary owners successfully updated.");
     } catch (e) {

--- a/src/ConnectToLedger.ts
+++ b/src/ConnectToLedger.ts
@@ -16,7 +16,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { QldbDriver  } from "amazon-qldb-driver-nodejs";
+import { QldbDriver, RetryConfig  } from "amazon-qldb-driver-nodejs";
 import { ClientConfiguration } from "aws-sdk/clients/qldbsession";
 
 import { LEDGER_NAME } from "./qldb/Constants";
@@ -34,9 +34,14 @@ export function createQldbDriver(
     ledgerName: string = LEDGER_NAME,
     serviceConfigurationOptions: ClientConfiguration = {}
 ): QldbDriver {
-    const qldbDriver: QldbDriver = new QldbDriver(ledgerName, serviceConfigurationOptions);
+    const retryLimit = 4;
+    const maxConcurrentTransactions = 10;
+    //Use driver's default backoff function (and hence, no second parameter provided to RetryConfig)
+    const retryConfig: RetryConfig  = new RetryConfig(retryLimit);
+    const qldbDriver: QldbDriver = new QldbDriver(ledgerName, serviceConfigurationOptions, 10, retryConfig);
     return qldbDriver;
 }
+
 
 export function getQldbDriver(): QldbDriver {
     return qldbDriver;

--- a/src/CreateIndex.ts
+++ b/src/CreateIndex.ts
@@ -67,7 +67,7 @@ var main = async function(): Promise<void> {
                 createIndex(txn, DRIVERS_LICENSE_TABLE_NAME, PERSON_ID_INDEX_NAME),
                 createIndex(txn, DRIVERS_LICENSE_TABLE_NAME, LICENSE_NUMBER_INDEX_NAME)
             ]);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to create indexes: ${e}`);
     }

--- a/src/CreateTable.ts
+++ b/src/CreateTable.ts
@@ -55,7 +55,7 @@ var main = async function(): Promise<void> {
                 createTable(txn, PERSON_TABLE_NAME),
                 createTable(txn, DRIVERS_LICENSE_TABLE_NAME)
             ]);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to create tables: ${e}`);
     }

--- a/src/DeregisterDriversLicense.ts
+++ b/src/DeregisterDriversLicense.ts
@@ -51,7 +51,7 @@ var main = async function(): Promise<void> {
         const qldbDriver: QldbDriver = getQldbDriver();
         await qldbDriver.executeLambda(async (txn: TransactionExecutor) => {
             await deregisterDriversLicense(txn, DRIVERS_LICENSE[1].LicenseNumber);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Error de-registering driver's license: ${e}`);
     }

--- a/src/FindVehicles.ts
+++ b/src/FindVehicles.ts
@@ -53,7 +53,7 @@ var main = async function(): Promise<void> {
         const qldbDriver: QldbDriver = getQldbDriver();
         await qldbDriver.executeLambda(async (txn: TransactionExecutor) => {
             await findVehiclesForOwner(txn, PERSON[0].GovId);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Error getting vehicles for owner: ${e}`);
     }

--- a/src/GetBlock.ts
+++ b/src/GetBlock.ts
@@ -164,7 +164,7 @@ var main = async function(): Promise<void> {
                 const blockAddress: ValueHolder = blockAddressToValueHolder(registration);
                 await verifyBlock(LEDGER_NAME, blockAddress, qldbClient);
             }
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to query vehicle registration by Vin: ${e}`);
     }

--- a/src/InsertDocument.ts
+++ b/src/InsertDocument.ts
@@ -88,7 +88,7 @@ var main = async function(): Promise<void> {
         const qldbDriver: QldbDriver = getQldbDriver();
         await qldbDriver.executeLambda(async (txn: TransactionExecutor) => {
             await updateAndInsertDocuments(txn);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to insert documents: ${e}`);
     }

--- a/src/QueryHistory.ts
+++ b/src/QueryHistory.ts
@@ -60,7 +60,7 @@ var main = async function(): Promise<void> {
         const vin: string = VEHICLE_REGISTRATION[0].VIN;
         await qldbDriver.executeLambda(async (txn: TransactionExecutor) => {
             await previousPrimaryOwners(txn, vin);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to query history to find previous owners: ${e}`);
     }

--- a/src/RegisterDriversLicense.ts
+++ b/src/RegisterDriversLicense.ts
@@ -130,7 +130,7 @@ var main = async function(): Promise<void> {
             }
             newLicense.PersonId = documentId;
             await registerNewDriversLicense(txn, newLicense, documentId);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to register drivers license: ${e}`);
     }

--- a/src/RenewDriversLicense.ts
+++ b/src/RenewDriversLicense.ts
@@ -110,7 +110,7 @@ var main = async function(): Promise<void> {
             if (await verifyDriverFromLicenseNumber(txn, personId)) {
                 await renewDriversLicense(txn, fromDate, toDate, licenseNumber);
             }
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to renew drivers license: ${e}`);
     }

--- a/src/ScanTable.ts
+++ b/src/ScanTable.ts
@@ -58,7 +58,7 @@ var main = async function(): Promise<void> {
                     prettyPrintResultList(result.getResultList());
                 });
             }
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         log(`Error displaying documents: ${e}`);
     }

--- a/src/TransferVehicleOwnership.ts
+++ b/src/TransferVehicleOwnership.ts
@@ -130,7 +130,7 @@ var main = async function(): Promise<void> {
 
         await qldbDriver.executeLambda(async (txn: TransactionExecutor) => {
             await validateAndUpdateRegistration(txn, vin, previousOwnerGovId,  newPrimaryOwnerGovId);
-        }, () => log("Retrying due to OCC conflict..."));
+        });
     } catch (e) {
         error(`Unable to connect and run queries: ${e}`);
     }


### PR DESCRIPTION
Upgraded the version of [Amazon QLDB driver to v2.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0-rc.1) , which introduced a few changes which makes it easy to use the driver.

The new version `v2.0.0-rc.1` has a breaking change of replacing the `RetryIndicator` argument of `QldbDriver.executeLambda` with `RetryConfig`.  In this PR, we have defined a new `RetryConfig` at the driver level and removed the `retryIndicator` argument from all `executeLambda` methods

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
