### PR TITLE
Update the Sample app to use Amazon QLDB Node.js Driver v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-qldb-dmv-sample-nodejs",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "@types/node": "^12.0.2",
-    "amazon-qldb-driver-nodejs": "2.0.0-rc.1",
+    "amazon-qldb-driver-nodejs": "2.0.0",
     "aws-sdk": "^2.564.0",
     "ion-js": "~4.0.0",
     "jsbi": "^3.1.1"
   },
   "name": "amazon-qldb-dmv-sample-nodejs",
   "description": "Amazon Quantum Ledger Database Node.js sample application",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {


### PR DESCRIPTION
Upgrade version of Amazon QLDB driver to [v2.0.0](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0) . There are no code changes introduced between [v2.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0-rc.1) and [v2.0.0](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0) of the driver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
