### PR TITLE
Fix incorrect variable syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: $${ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Github actions was failing because it was trying to reference matrix.os variable but it was incorrect syntax. Updated to the correct syntax.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
