### PR TITLE
Fix time error when querying with history()

### DIFF
--- a/src/QueryHistory.ts
+++ b/src/QueryHistory.ts
@@ -35,6 +35,9 @@ import { getDocumentId } from "./qldb/Util";
 async function previousPrimaryOwners(txn: TransactionExecutor, vin: string): Promise<void> {
     const documentId: string = await getDocumentId(txn, VEHICLE_REGISTRATION_TABLE_NAME, "VIN", vin);
     const todaysDate: Date = new Date();
+    // set todaysDate back one minute to ensure end time is in the past 
+    // by the time the request reaches our backend
+    todaysDate.setMinutes(todaysDate.getMinutes() - 1);
     const threeMonthsAgo: Date = new Date(todaysDate);
     threeMonthsAgo.setMonth(todaysDate.getMonth() - 3);
 


### PR DESCRIPTION
*Issue #, if available:*
#190 

*Description of changes:*
Previously, the code was making a `history()` query with no margin of error ensuring the clock on the backend machine is at least ahead of the local machine. This change adds a margin of error of 1 minute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
