### PR TITLE
Fix AssertionError

### DIFF
--- a/src/InsertIonTypes.ts
+++ b/src/InsertIonTypes.ts
@@ -96,7 +96,7 @@ const main = async function(): Promise<void> {
             await updateRecordAndVerifyType(txn, 3.2, IonTypes.FLOAT);
             await updateRecordAndVerifyType(txn, dom.load("5.5"), IonTypes.DECIMAL);
             await updateRecordAndVerifyType(txn, dom.load("2020-02-02"), IonTypes.TIMESTAMP);
-            await updateRecordAndVerifyType(txn, dom.load("abc123"), IonTypes.STRING);
+            await updateRecordAndVerifyType(txn, dom.load("abc123"), IonTypes.SYMBOL);
             await updateRecordAndVerifyType(txn, dom.load("\"string\""), IonTypes.STRING);
             await updateRecordAndVerifyType(txn, dom.load("{{ \"clob\" }}"), IonTypes.CLOB);
             await updateRecordAndVerifyType(txn, dom.load("{{ blob }}"), IonTypes.BLOB);


### PR DESCRIPTION
The string `"abc123"` should convert to an Ion Symbol represented by an Identifier, whereas an Ion String must be delimited by double-quotes, e.g. `"\"string\""`.

> Identifier: an unquoted sequence of one or more ASCII letters, digits, or the characters $ (dollar sign) or _ (underscore), not starting with a digit.

See https://amzn.github.io/ion-docs/docs/symbols.html for further details.

*Issue #, if available:*
#322 

*Description of changes:*
Match `dom.load("abc123")` to `IonTypes.SYMBOL` instead of `IonTypes.STRING`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
